### PR TITLE
Fix GUI overlay lambda and client tick handling

### DIFF
--- a/src/main/java/org/deymosko/lootroll/events/ClientEvents.java
+++ b/src/main/java/org/deymosko/lootroll/events/ClientEvents.java
@@ -1,18 +1,14 @@
 package org.deymosko.lootroll.events;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RegisterGuiOverlaysEvent;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
-import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import org.deymosko.lootroll.ClientVoteCache;
 import org.deymosko.lootroll.Lootroll;
 import org.deymosko.lootroll.events.input.Keybinds;
-import org.deymosko.lootroll.gui.LootVoteScreen;
 import org.deymosko.lootroll.gui.VoteHUDOverlay;
 
 @Mod.EventBusSubscriber(modid = Lootroll.MODID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD)
@@ -30,22 +26,8 @@ public class ClientEvents {
 
     @SubscribeEvent
     public static void onRegisterOverlays(RegisterGuiOverlaysEvent event) {
-        event.registerAboveAll("loot_vote", guiGraphics -> {
+        event.registerAboveAll("loot_vote", (guiGraphics, partialTick, width, height) -> {
             VoteHUDOverlay.render(guiGraphics);
         });
-    }
-    @SubscribeEvent
-    public static void onClientTick(TickEvent.ClientTickEvent event) {
-        if (event.phase != TickEvent.Phase.END) return;
-
-        Minecraft mc = Minecraft.getInstance();
-        if (mc.player == null || mc.level == null) return;
-
-        while (Keybinds.openVoteMenu.consumeClick()) {
-            if (ClientVoteCache.hasVote()) {
-                mc.setScreen(new LootVoteScreen(ClientVoteCache.getVote()));
-                ClientVoteCache.clear();
-            }
-        }
     }
 }

--- a/src/main/java/org/deymosko/lootroll/events/ClientForgeEvents.java
+++ b/src/main/java/org/deymosko/lootroll/events/ClientForgeEvents.java
@@ -1,0 +1,30 @@
+package org.deymosko.lootroll.events;
+
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import org.deymosko.lootroll.ClientVoteCache;
+import org.deymosko.lootroll.Lootroll;
+import org.deymosko.lootroll.events.input.Keybinds;
+import org.deymosko.lootroll.gui.LootVoteScreen;
+
+@Mod.EventBusSubscriber(modid = Lootroll.MODID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class ClientForgeEvents {
+
+    @SubscribeEvent
+    public static void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END) return;
+
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.player == null || mc.level == null) return;
+
+        while (Keybinds.openVoteMenu.consumeClick()) {
+            if (ClientVoteCache.hasVote()) {
+                mc.setScreen(new LootVoteScreen(ClientVoteCache.getVote()));
+                ClientVoteCache.clear();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix registration of VoteHUDOverlay with correct IGuiOverlay lambda
- move ClientTickEvent handler into a separate `ClientForgeEvents` class registered on the Forge bus

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687cea98c86c832181f69e4644872922