### PR TITLE
Fix loot vote gui

### DIFF
--- a/src/main/java/org/deymosko/lootroll/ClientVoteCache.java
+++ b/src/main/java/org/deymosko/lootroll/ClientVoteCache.java
@@ -6,35 +6,36 @@ import java.util.*;
 
 public class ClientVoteCache {
 
-    private static final Set<UUID> pendingVotes = new HashSet<>();
-    private static ItemStack activeVote = ItemStack.EMPTY;
+    private static final Map<UUID, ItemStack> voteQueue = new LinkedHashMap<>();
 
 
-    public static void add(UUID id) {
-        pendingVotes.add(id);
+    public static void add(UUID id, ItemStack item) {
+        voteQueue.putIfAbsent(id, item.copy());
     }
 
     public static void remove(UUID id) {
-        pendingVotes.remove(id);
+        voteQueue.remove(id);
     }
     public static Set<UUID> getPendingVotes() {
-        return Collections.unmodifiableSet(pendingVotes);
-    }
-
-    public static void addVote(ItemStack item) {
-        activeVote = item;
+        return Collections.unmodifiableSet(voteQueue.keySet());
     }
 
     public static boolean hasVote() {
-        return !activeVote.isEmpty();
+        return !voteQueue.isEmpty();
     }
 
-    public static ItemStack getVote() {
-        return activeVote;
+    public static ItemStack getCurrentItem() {
+        return voteQueue.isEmpty() ? ItemStack.EMPTY : voteQueue.values().iterator().next();
     }
 
-    public static void clear() {
-        activeVote = ItemStack.EMPTY;
+    public static UUID getCurrentId() {
+        return voteQueue.isEmpty() ? null : voteQueue.keySet().iterator().next();
+    }
+
+    public static void poll() {
+        if (!voteQueue.isEmpty()) {
+            voteQueue.remove(getCurrentId());
+        }
     }
 
 }

--- a/src/main/java/org/deymosko/lootroll/Lootroll.java
+++ b/src/main/java/org/deymosko/lootroll/Lootroll.java
@@ -39,6 +39,7 @@ import org.deymosko.lootroll.commands.RollCommand;
 import org.deymosko.lootroll.events.VoteManager;
 import org.deymosko.lootroll.events.VoteSession;
 import org.deymosko.lootroll.network.Packets;
+import org.deymosko.lootroll.network.s2c.VoteStartS2CPacket;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -102,7 +103,7 @@ public class Lootroll {
 
         Lootroll.LOGGER.info("Почато голосування за {}, учасників: {}", testItem.getDisplayName().getString(), serverPlayers.size());
 
-        // TODO: тут пізніше — Packet до клієнтів
+        serverPlayers.forEach(p -> Packets.sendToClient(new VoteStartS2CPacket(session.getId(), testItem), p));
     }
 
     @SubscribeEvent

--- a/src/main/java/org/deymosko/lootroll/events/ClientForgeEvents.java
+++ b/src/main/java/org/deymosko/lootroll/events/ClientForgeEvents.java
@@ -22,8 +22,7 @@ public class ClientForgeEvents {
 
         while (Keybinds.openVoteMenu.consumeClick()) {
             if (ClientVoteCache.hasVote()) {
-                mc.setScreen(new LootVoteScreen(ClientVoteCache.getVote()));
-                ClientVoteCache.clear();
+                mc.setScreen(new LootVoteScreen(ClientVoteCache.getCurrentId(), ClientVoteCache.getCurrentItem()));
             }
         }
     }

--- a/src/main/java/org/deymosko/lootroll/events/VoteManager.java
+++ b/src/main/java/org/deymosko/lootroll/events/VoteManager.java
@@ -1,5 +1,8 @@
 package org.deymosko.lootroll.events;
 
+import net.minecraft.server.level.ServerPlayer;
+import org.deymosko.lootroll.enums.VoteType;
+
 import java.util.*;
 
 public class VoteManager {
@@ -28,5 +31,12 @@ public class VoteManager {
 
     public static Optional<VoteSession> get(UUID id) {
         return Optional.ofNullable(activeVotes.get(id));
+    }
+
+    public static void vote(UUID sessionId, ServerPlayer player, VoteType type) {
+        VoteSession session = activeVotes.get(sessionId);
+        if (session != null) {
+            session.vote(player.getUUID(), type);
+        }
     }
 }

--- a/src/main/java/org/deymosko/lootroll/events/input/Keybinds.java
+++ b/src/main/java/org/deymosko/lootroll/events/input/Keybinds.java
@@ -2,7 +2,6 @@ package org.deymosko.lootroll.events.input;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.client.KeyMapping;
-import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -17,13 +16,6 @@ public class Keybinds {
         MinecraftForge.EVENT_BUS.register(new Keybinds());
     }
 
-    @SubscribeEvent
-    public void onKeyPress(InputEvent.Key event) {
-        if (openVoteMenu.isActiveAndMatches(InputConstants.getKey(event.getKey(), event.getScanCode()))) {
-            // TODO: Відкрити меню голосування
-            System.out.println("[LootRoll] Відкриваємо меню голосування!");
-        }
-    }
 
     @SubscribeEvent
     public static void registerKeys(RegisterKeyMappingsEvent event) {

--- a/src/main/java/org/deymosko/lootroll/gui/LootVoteScreen.java
+++ b/src/main/java/org/deymosko/lootroll/gui/LootVoteScreen.java
@@ -6,14 +6,22 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import org.deymosko.lootroll.ClientVoteCache;
+import org.deymosko.lootroll.enums.VoteType;
+import org.deymosko.lootroll.network.Packets;
+import org.deymosko.lootroll.network.c2s.VoteC2SPacket;
+
+import java.util.UUID;
 
 public class LootVoteScreen extends Screen {
     private final ItemStack itemStack;
+    private final UUID voteId;
     private int timerTicks = 600; // 30 секунд при 20 тік/сек
     private Button needButton, greedButton, passButton;
 
-    public LootVoteScreen(ItemStack item) {
+    public LootVoteScreen(UUID voteId, ItemStack item) {
         super(Component.literal("Loot Vote"));
+        this.voteId = voteId;
         this.itemStack = item;
     }
 
@@ -62,7 +70,14 @@ public class LootVoteScreen extends Screen {
     }
 
     private void vote(String type) {
-        // TODO: Надіслати на сервер
+        VoteType voteType = switch (type) {
+            case "need" -> VoteType.NEED;
+            case "greed" -> VoteType.GREED;
+            default -> VoteType.PASS;
+        };
+
+        Packets.sendToServer(new VoteC2SPacket(voteId, voteType));
+        ClientVoteCache.poll();
         minecraft.setScreen(null); // Закриває екран
     }
 

--- a/src/main/java/org/deymosko/lootroll/gui/VoteHUDOverlay.java
+++ b/src/main/java/org/deymosko/lootroll/gui/VoteHUDOverlay.java
@@ -1,12 +1,9 @@
 package org.deymosko.lootroll.gui;
 
 
-import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import net.minecraftforge.client.event.RenderGuiOverlayEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import org.deymosko.lootroll.ClientVoteCache;
 
 
@@ -16,7 +13,7 @@ public class VoteHUDOverlay {
 
     public static void render(GuiGraphics gui) {
         if (mc.player == null || mc.level == null) return;
-        if (ClientVoteCache.getPendingVotes().isEmpty()) return;
+        if (!ClientVoteCache.hasVote()) return;
 
         int x = mc.getWindow().getGuiScaledWidth() - 160;
         int y = 10;

--- a/src/main/java/org/deymosko/lootroll/network/Packets.java
+++ b/src/main/java/org/deymosko/lootroll/network/Packets.java
@@ -2,10 +2,13 @@ package org.deymosko.lootroll.network;
 
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkRegistry;
 import net.minecraftforge.network.PacketDistributor;
 import net.minecraftforge.network.simple.SimpleChannel;
 import org.deymosko.lootroll.Lootroll;
+import org.deymosko.lootroll.network.c2s.VoteC2SPacket;
+import org.deymosko.lootroll.network.s2c.VoteStartS2CPacket;
 
 public class Packets
 {
@@ -28,6 +31,18 @@ public class Packets
                 .serverAcceptedVersions(s -> true)
                 .simpleChannel();
         INSTANCE = net;
+
+        net.messageBuilder(VoteStartS2CPacket.class, id(), NetworkDirection.PLAY_TO_CLIENT)
+                .encoder(VoteStartS2CPacket::encode)
+                .decoder(VoteStartS2CPacket::decode)
+                .consumerMainThread(VoteStartS2CPacket::handle)
+                .add();
+
+        net.messageBuilder(VoteC2SPacket.class, id(), NetworkDirection.PLAY_TO_SERVER)
+                .encoder(VoteC2SPacket::encode)
+                .decoder(VoteC2SPacket::decode)
+                .consumerMainThread(VoteC2SPacket::handle)
+                .add();
 
     }
     public static <MSG> void sendToServer(MSG message) {INSTANCE.sendToServer(message);}

--- a/src/main/java/org/deymosko/lootroll/network/c2s/VoteC2SPacket.java
+++ b/src/main/java/org/deymosko/lootroll/network/c2s/VoteC2SPacket.java
@@ -1,4 +1,39 @@
 package org.deymosko.lootroll.network.c2s;
 
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkEvent;
+import org.deymosko.lootroll.events.VoteManager;
+import org.deymosko.lootroll.enums.VoteType;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
 public class VoteC2SPacket {
+    private final UUID voteId;
+    private final VoteType type;
+
+    public VoteC2SPacket(UUID voteId, VoteType type) {
+        this.voteId = voteId;
+        this.type = type;
+    }
+
+    public static void encode(VoteC2SPacket msg, FriendlyByteBuf buf) {
+        buf.writeUUID(msg.voteId);
+        buf.writeEnum(msg.type);
+    }
+
+    public static VoteC2SPacket decode(FriendlyByteBuf buf) {
+        return new VoteC2SPacket(buf.readUUID(), buf.readEnum(VoteType.class));
+    }
+
+    public static void handle(VoteC2SPacket msg, Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            ServerPlayer player = ctx.get().getSender();
+            if (player != null) {
+                VoteManager.vote(msg.voteId, player, msg.type);
+            }
+        });
+        ctx.get().setPacketHandled(true);
+    }
 }

--- a/src/main/java/org/deymosko/lootroll/network/s2c/VoteStartS2CPacket.java
+++ b/src/main/java/org/deymosko/lootroll/network/s2c/VoteStartS2CPacket.java
@@ -27,10 +27,7 @@ public class VoteStartS2CPacket {
     }
 
     public static void handle(VoteStartS2CPacket msg, Supplier<NetworkEvent.Context> ctx) {
-        ctx.get().enqueueWork(() -> {
-            ClientVoteCache.add(msg.voteId);
-            ClientVoteCache.addVote(msg.item);
-        });
+        ctx.get().enqueueWork(() -> ClientVoteCache.add(msg.voteId, msg.item));
         ctx.get().setPacketHandled(true);
     }
 }


### PR DESCRIPTION
## Summary
- fix HUD overlay not showing and implement vote screen queue
- implement client/server packets for starting and answering loot votes
- use keybind with client tick to open queued votes

## Testing
- `./gradlew build` *(fails: unable to fetch gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_687cf4ca87708321976d6a642d34d670