### PR TITLE
Implement vote timer sync and chat results

### DIFF
--- a/src/main/java/org/deymosko/lootroll/ClientVoteCache.java
+++ b/src/main/java/org/deymosko/lootroll/ClientVoteCache.java
@@ -6,11 +6,13 @@ import java.util.*;
 
 public class ClientVoteCache {
 
-    private static final Map<UUID, ItemStack> voteQueue = new LinkedHashMap<>();
+    public record VoteData(ItemStack item, long endTime) {}
+
+    private static final Map<UUID, VoteData> voteQueue = new LinkedHashMap<>();
 
 
-    public static void add(UUID id, ItemStack item) {
-        voteQueue.putIfAbsent(id, item.copy());
+    public static void add(UUID id, ItemStack item, long endTime) {
+        voteQueue.putIfAbsent(id, new VoteData(item.copy(), endTime));
     }
 
     public static void remove(UUID id) {
@@ -25,11 +27,15 @@ public class ClientVoteCache {
     }
 
     public static ItemStack getCurrentItem() {
-        return voteQueue.isEmpty() ? ItemStack.EMPTY : voteQueue.values().iterator().next();
+        return voteQueue.isEmpty() ? ItemStack.EMPTY : voteQueue.values().iterator().next().item();
     }
 
     public static UUID getCurrentId() {
         return voteQueue.isEmpty() ? null : voteQueue.keySet().iterator().next();
+    }
+
+    public static long getCurrentEndTime() {
+        return voteQueue.isEmpty() ? System.currentTimeMillis() : voteQueue.values().iterator().next().endTime();
     }
 
     public static void poll() {

--- a/src/main/java/org/deymosko/lootroll/LootDropHandler.java
+++ b/src/main/java/org/deymosko/lootroll/LootDropHandler.java
@@ -60,7 +60,7 @@ public class LootDropHandler {
 
         for (ServerPlayer p : serverPlayers) {
             Lootroll.LOGGER.info("→ Поблизу гравець: {}", p.getName().getString());
-            Packets.sendToClient(new VoteStartS2CPacket(session.getId(), testItem), p);
+            Packets.sendToClient(new VoteStartS2CPacket(session.getId(), testItem, session.getEndTime()), p);
         }
     }
 }

--- a/src/main/java/org/deymosko/lootroll/Lootroll.java
+++ b/src/main/java/org/deymosko/lootroll/Lootroll.java
@@ -108,7 +108,7 @@ public class Lootroll {
 
         Lootroll.LOGGER.info("Почато голосування за {}, учасників: {}", testItem.getDisplayName().getString(), serverPlayers.size());
 
-        serverPlayers.forEach(p -> Packets.sendToClient(new VoteStartS2CPacket(session.getId(), testItem), p));
+        serverPlayers.forEach(p -> Packets.sendToClient(new VoteStartS2CPacket(session.getId(), testItem, session.getEndTime()), p));
     }
 
     @SubscribeEvent

--- a/src/main/java/org/deymosko/lootroll/events/ClientForgeEvents.java
+++ b/src/main/java/org/deymosko/lootroll/events/ClientForgeEvents.java
@@ -22,7 +22,7 @@ public class ClientForgeEvents {
 
         while (Keybinds.openVoteMenu.consumeClick()) {
             if (ClientVoteCache.hasVote()) {
-                mc.setScreen(new LootVoteScreen(ClientVoteCache.getCurrentId(), ClientVoteCache.getCurrentItem()));
+                mc.setScreen(new LootVoteScreen(ClientVoteCache.getCurrentId(), ClientVoteCache.getCurrentItem(), ClientVoteCache.getCurrentEndTime()));
             }
         }
     }

--- a/src/main/java/org/deymosko/lootroll/events/VoteManager.java
+++ b/src/main/java/org/deymosko/lootroll/events/VoteManager.java
@@ -23,7 +23,8 @@ public class VoteManager {
         for (VoteSession session : activeVotes.values()) {
             if (session.isFinished()) {
                 finished.add(session.getId());
-                session.getWinner().ifPresent(winner ->
+                Optional<UUID> winnerOpt = session.getWinner();
+                winnerOpt.ifPresent(winner ->
                 {
                     System.out.println("[VoteManager] Переможець голосування " + session.getId() + ": " + winner);
 
@@ -37,11 +38,33 @@ public class VoteManager {
                             break;
                         }
                     }
-
-
                 });
+
+                // Повідомляємо результати всім учасникам
+                String itemName = session.getItem().getHoverName().getString();
+                for (ServerPlayer p : session.getParticipants()) {
+                    p.sendSystemMessage(Component.literal("Результати голосування за " + itemName + ":"));
+                    session.getVotes().forEach((id, vote) -> {
+                        int roll = session.getRolls().getOrDefault(id, 0);
+                        String name = session.getParticipants().stream()
+                                .filter(sp -> sp.getUUID().equals(id))
+                                .findFirst()
+                                .map(sp -> sp.getName().getString())
+                                .orElse(id.toString());
+                        p.sendSystemMessage(Component.literal(" - " + name + " " + vote + " " + roll));
+                    });
+                    winnerOpt.ifPresent(win -> {
+                        String winnerName = session.getParticipants().stream()
+                                .filter(sp -> sp.getUUID().equals(win))
+                                .findFirst()
+                                .map(sp -> sp.getName().getString())
+                                .orElse(win.toString());
+                        p.sendSystemMessage(Component.literal("Переможець: " + winnerName));
+                    });
+                }
             }
         }
+        finished.forEach(activeVotes::remove);
     }
 
     public static Optional<VoteSession> get(UUID id) {
@@ -51,8 +74,21 @@ public class VoteManager {
     public static void vote(UUID sessionId, ServerPlayer player, VoteType type) {
         VoteSession session = activeVotes.get(sessionId);
         if (session != null) {
-            System.out.println("[VoteManager] " + player.getName() + " is already voted");
+            if (session.getVotes().containsKey(player.getUUID())) {
+                player.sendSystemMessage(Component.literal("Ви вже проголосували"));
+                return;
+            }
             session.vote(player.getUUID(), type);
+
+            String itemName = session.getItem().getHoverName().getString();
+            int roll = session.getRolls().getOrDefault(player.getUUID(), 0);
+            for (ServerPlayer p : session.getParticipants()) {
+                if (type == VoteType.PASS) {
+                    p.sendSystemMessage(Component.literal(player.getName().getString() + " пасує за " + itemName));
+                } else {
+                    p.sendSystemMessage(Component.literal(player.getName().getString() + " кидає " + roll + " за " + itemName + " (" + type + ")"));
+                }
+            }
         }
     }
 }

--- a/src/main/java/org/deymosko/lootroll/events/VoteSession.java
+++ b/src/main/java/org/deymosko/lootroll/events/VoteSession.java
@@ -86,5 +86,9 @@ public class VoteSession {
     public long getTimeLeftMs() {
         return Math.max(0, endTime - System.currentTimeMillis());
     }
+
+    public long getEndTime() {
+        return endTime;
+    }
 }
 

--- a/src/main/java/org/deymosko/lootroll/gui/LootVoteScreen.java
+++ b/src/main/java/org/deymosko/lootroll/gui/LootVoteScreen.java
@@ -20,14 +20,17 @@ import java.util.UUID;
 public class LootVoteScreen extends Screen {
     private final ItemStack itemStack;
     private final UUID voteId;
-    private int timerTicks = 600; // 30 секунд при 20 тік/сек
+    private final long endTime;
+    private int timerTicks;
     private HoverableImageButton needButton, greedButton, passButton;
     private VoteSession session;
 
-    public LootVoteScreen(UUID voteId, ItemStack item) {
+    public LootVoteScreen(UUID voteId, ItemStack item, long endTime) {
         super(Component.literal("Loot Vote"));
         this.voteId = voteId;
         this.itemStack = item;
+        this.endTime = endTime;
+        this.timerTicks = (int) Math.ceil(Math.max(0, endTime - System.currentTimeMillis()) / 50.0);
     }
 
     @Override
@@ -87,7 +90,7 @@ public class LootVoteScreen extends Screen {
 
 
         // Таймер
-        gui.drawString(this.font, "Time left: " + (timerTicks / 20), centerX - 30, centerY - 35, 0xFFFFFF);
+        gui.drawString(this.font, "Time left: " + (int)Math.ceil(Math.max(0, endTime - System.currentTimeMillis()) / 1000.0), centerX - 30, centerY - 35, 0xFFFFFF);
 
         super.render(gui, mouseX, mouseY, partialTick);
     }
@@ -109,7 +112,8 @@ public class LootVoteScreen extends Screen {
 
     @Override
     public void tick() {
-        if (--timerTicks <= 0) {
+        timerTicks = (int) Math.ceil(Math.max(0, endTime - System.currentTimeMillis()) / 50.0);
+        if (timerTicks <= 0) {
             onTimeout();
         }
     }

--- a/src/main/java/org/deymosko/lootroll/network/s2c/VoteStartS2CPacket.java
+++ b/src/main/java/org/deymosko/lootroll/network/s2c/VoteStartS2CPacket.java
@@ -11,23 +11,26 @@ import java.util.function.Supplier;
 public class VoteStartS2CPacket {
     private final UUID voteId;
     private final ItemStack item;
+    private final long endTime;
 
-    public VoteStartS2CPacket(UUID voteId, ItemStack item) {
+    public VoteStartS2CPacket(UUID voteId, ItemStack item, long endTime) {
         this.voteId = voteId;
         this.item = item;
+        this.endTime = endTime;
     }
 
     public static void encode(VoteStartS2CPacket msg, FriendlyByteBuf buf) {
         buf.writeUUID(msg.voteId);
         buf.writeItem(msg.item);
+        buf.writeLong(msg.endTime);
     }
 
     public static VoteStartS2CPacket decode(FriendlyByteBuf buf) {
-        return new VoteStartS2CPacket(buf.readUUID(), buf.readItem());
+        return new VoteStartS2CPacket(buf.readUUID(), buf.readItem(), buf.readLong());
     }
 
     public static void handle(VoteStartS2CPacket msg, Supplier<NetworkEvent.Context> ctx) {
-        ctx.get().enqueueWork(() -> ClientVoteCache.add(msg.voteId, msg.item));
+        ctx.get().enqueueWork(() -> ClientVoteCache.add(msg.voteId, msg.item, msg.endTime));
         ctx.get().setPacketHandled(true);
     }
 }


### PR DESCRIPTION
## Summary
- sync loot vote screen timer with server time
- broadcast dice roll results on vote
- announce final results and give item to winner
- track vote end time on client via new packet field

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687d0de8a3c48321a24ab286efa6e4c6