### PR TITLE
Implement multi-vote LootVoteScreen

### DIFF
--- a/src/main/java/org/deymosko/lootroll/ClientVoteCache.java
+++ b/src/main/java/org/deymosko/lootroll/ClientVoteCache.java
@@ -18,6 +18,10 @@ public class ClientVoteCache {
         voteQueue.remove(id);
     }
 
+    public static VoteData get(UUID id) {
+        return voteQueue.get(id);
+    }
+
     public static Set<UUID> getPendingVotes() {
         return Collections.unmodifiableSet(voteQueue.keySet());
     }

--- a/src/main/java/org/deymosko/lootroll/events/ClientForgeEvents.java
+++ b/src/main/java/org/deymosko/lootroll/events/ClientForgeEvents.java
@@ -22,7 +22,7 @@ public class ClientForgeEvents {
 
         while (Keybinds.openVoteMenu.consumeClick()) {
             if (ClientVoteCache.hasVote()) {
-                mc.setScreen(new LootVoteScreen(ClientVoteCache.getCurrentId(), ClientVoteCache.getCurrentItems(), ClientVoteCache.getCurrentEndTime()));
+                mc.setScreen(new LootVoteScreen());
             }
         }
     }

--- a/src/main/java/org/deymosko/lootroll/gui/LootVoteScreen.java
+++ b/src/main/java/org/deymosko/lootroll/gui/LootVoteScreen.java
@@ -1,183 +1,105 @@
 package org.deymosko.lootroll.gui;
 
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 import org.deymosko.lootroll.ClientVoteCache;
 import org.deymosko.lootroll.enums.VoteType;
-import org.deymosko.lootroll.events.VoteSession;
 import org.deymosko.lootroll.network.Packets;
 import org.deymosko.lootroll.network.c2s.VoteC2SPacket;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 public class LootVoteScreen extends Screen {
-    private final List<ItemStack> itemStack;
-    private final UUID voteId;
-    private final long endTime;
-    private int timerTicks;
-    private HoverableImageButton needButton, greedButton, passButton;
-    private VoteSession session;
-    private int overlay = 0;
+    private final List<VoteUIEntry> entries = new ArrayList<>();
 
-
-    public LootVoteScreen(UUID voteId, List<ItemStack> item, long endTime) {
+    public LootVoteScreen() {
         super(Component.literal("Loot Vote"));
-        this.voteId = voteId;
-        this.itemStack = item;
-        this.endTime = endTime;
-        this.timerTicks = (int) Math.ceil(Math.max(0, endTime - System.currentTimeMillis()) / 50.0);
-    }
-
-
-    private int guiElementsX(int x)
-    {
-        overlay++;
-        return x * overlay;
-    }
-    private int guiElementsY(int y)
-    {
-        overlay++;
-        return y * overlay;
     }
 
     @Override
     protected void init() {
-        int centerX = width / 2;
-        int centerY = height / 2;
+        reloadEntries();
+    }
 
-        needButton = new HoverableImageButton(centerX - 80 + 117, centerY+80+6, 16, 16, GuiTextures.NEED_BUTTON, GuiTextures.NEED_BUTTON_HOVER, () ->
-        {
-            vote(VoteType.NEED.toString());
-        }, "");
-        greedButton = new HoverableImageButton(centerX -80 + 116, centerY+80+25, 17, 10, GuiTextures.GREED_BUTTON, GuiTextures.GREED_BUTTON_HOVER, () ->
-        {
-            vote(VoteType.GREED.toString());
-        }, "");
-        passButton = new HoverableImageButton(centerX + -80 + 139, centerY + 80 + 6, 14, 14, GuiTextures.PASS_BUTTON, GuiTextures.PASS_BUTTON_HOVER, () ->
-        {
-            vote(VoteType.PASS.toString());
-        }, "");
+    private void reloadEntries() {
+        entries.clear();
+        for (UUID id : ClientVoteCache.getPendingVotes()) {
+            ClientVoteCache.VoteData data = ClientVoteCache.get(id);
+            if (data != null) {
+                VoteUIEntry entry = new VoteUIEntry(id, data.items(), data.endTime());
+                entries.add(entry);
+            }
+        }
+        layoutEntries();
+    }
 
-        addRenderableWidget(needButton);
-        addRenderableWidget(greedButton);
-        addRenderableWidget(passButton);
+    private void layoutEntries() {
+        clearWidgets();
+        int centerX = width / 2 - 80;
+        int startY = 20;
+        int offset = 50;
+        for (int i = 0; i < entries.size(); i++) {
+            VoteUIEntry entry = entries.get(i);
+            int y = startY + i * offset;
+            entry.initButtons(centerX, y, this);
+            addRenderableWidget(entry.getNeedButton());
+            addRenderableWidget(entry.getGreedButton());
+            addRenderableWidget(entry.getPassButton());
+        }
     }
 
     @Override
     public void render(GuiGraphics gui, int mouseX, int mouseY, float partialTick) {
         renderBackground(gui);
-        Minecraft mc = Minecraft.getInstance();
-        int centerX = width / 2;
-        int centerY = height / 2;
-        ItemStack stack = itemStack.get(0);
-
-
-        // Координати предмета
-        int itemX = centerX - 80 + 8;
-        int itemY = centerY + 80 + 10;
-
-        gui.renderItem(itemStack.get(0), itemX, itemY);
-
-// Якщо курсор наведений на предмет — показати tooltip
-        if (mouseX >= itemX && mouseX <= itemX + 16 && mouseY >= itemY && mouseY <= itemY + 16) {
-
-            gui.renderTooltip(this.font, itemStack.get(0), mouseX, mouseY);
+        Font font = Minecraft.getInstance().font;
+        for (int i = 0; i < entries.size(); i++) {
+            VoteUIEntry entry = entries.get(i);
+            entry.render(gui, mouseX, mouseY, font);
         }
-
-
-        // Фрейм
-        RenderSystem.setShaderTexture(0, GuiTextures.LOOTFRAME);
-        gui.blit(GuiTextures.LOOTFRAME, centerX - 80, centerY+80, 0, 0, 160, 40, 160, 40);
-
-        // Предмет
-        gui.renderItem(itemStack.get(0), itemX, itemY);
-
-        drawScaledString(gui, this.font, itemStack.get(0).getDisplayName().getString(), centerX-80+33, centerY + 80+9, 0.4f, 0xFFFFFF);
-        float progress = timerTicks / 600.0f;
-        drawProgressBar(gui, progress, centerX-80+6, centerY+80+33, 104, 5, 0xFFB2CA5D);
-
-
-        // Таймер
-        gui.drawString(this.font, "Time left: " + (int)Math.ceil(Math.max(0, endTime - System.currentTimeMillis()) / 1000.0), centerX - 30, centerY - 35, 0xFFFFFF);
-        if (stack.getCount() > 1) {
-            String countText = String.valueOf(stack.getCount());
-            gui.drawString(
-                    this.font,
-                    countText,
-                    itemX + 17 - this.font.width(countText),
-                    itemY + 9,
-                    0xFFFFFF,
-                    true
-            );
-        }
-
         super.render(gui, mouseX, mouseY, partialTick);
     }
+
     @Override
     public boolean isPauseScreen() {
         return false;
     }
-    @Override
-    public void renderBackground(GuiGraphics guiGraphics) {
-        // Не малюємо затемнення
-    }
-    public static void drawScaledString(GuiGraphics guiGraphics, Font font, String text, float screenX, float screenY, float scale, int color) {
-        PoseStack pose = guiGraphics.pose();
-        pose.pushPose();
-
-        // Коригуємо координати під масштаб
-        float scaledX = screenX / scale;
-        float scaledY = screenY / scale;
-
-        pose.scale(scale, scale, 1.0f);
-        guiGraphics.drawString(font, text, scaledX, scaledY, color, false);
-
-        pose.popPose();
-    }
-
-    private void drawProgressBar(GuiGraphics graphics, float progress, int x, int y, int width, int height, int color)
-    {
-        progress = Math.min(Math.max(progress, 0.0f), 1.0f);
-        int filledWidth = (int)(width * progress);
-        int filledHeight = (int)(height * progress);
-        graphics.fill(x, y, x + filledWidth, y + height, color);
-
-    }
-
-
 
     @Override
     public void tick() {
-        timerTicks = (int) Math.ceil(Math.max(0, endTime - System.currentTimeMillis()) / 50.0);
-        if (timerTicks <= 0) {
-            onTimeout();
+        List<VoteUIEntry> expired = new ArrayList<>();
+        for (VoteUIEntry entry : entries) {
+            if (entry.tick()) {
+                expired.add(entry);
+            }
+        }
+        for (VoteUIEntry e : expired) {
+            vote(e.getVoteId(), VoteType.PASS);
         }
     }
 
-    private void vote(String type) {
-        VoteType voteType = switch (type) {
-            case "NEED" -> VoteType.NEED;
-            case "GREED" -> VoteType.GREED;
-            default -> VoteType.PASS;
-        };
-
-        Packets.sendToServer(new VoteC2SPacket(voteId, voteType));
-        ClientVoteCache.poll();
-        minecraft.setScreen(null); // Закриває екран
+    public void vote(UUID id, VoteType type) {
+        Packets.sendToServer(new VoteC2SPacket(id, type));
+        ClientVoteCache.remove(id);
+        entries.removeIf(e -> e.getVoteId().equals(id));
+        if (entries.isEmpty()) {
+            Minecraft.getInstance().setScreen(null);
+        } else {
+            layoutEntries();
+        }
     }
 
-    private void onTimeout() {
-        // Якщо час вийшов — автоматичне "pass"
-        vote("pass");
+    public static void drawScaledString(GuiGraphics guiGraphics, Font font, String text, float screenX, float screenY, float scale, int color) {
+        var pose = guiGraphics.pose();
+        pose.pushPose();
+        float scaledX = screenX / scale;
+        float scaledY = screenY / scale;
+        pose.scale(scale, scale, 1.0f);
+        guiGraphics.drawString(font, text, scaledX, scaledY, color, false);
+        pose.popPose();
     }
 }
-

--- a/src/main/java/org/deymosko/lootroll/gui/VoteUIEntry.java
+++ b/src/main/java/org/deymosko/lootroll/gui/VoteUIEntry.java
@@ -1,0 +1,104 @@
+package org.deymosko.lootroll.gui;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+import org.deymosko.lootroll.enums.VoteType;
+
+import java.util.List;
+import java.util.UUID;
+
+public class VoteUIEntry {
+    private final UUID voteId;
+    private final List<ItemStack> items;
+    private final long endTime;
+    private int timerTicks;
+    private HoverableImageButton needButton;
+    private HoverableImageButton greedButton;
+    private HoverableImageButton passButton;
+    private int x;
+    private int y;
+
+    public VoteUIEntry(UUID voteId, List<ItemStack> items, long endTime) {
+        this.voteId = voteId;
+        this.items = items;
+        this.endTime = endTime;
+        this.timerTicks = (int)Math.ceil(Math.max(0, endTime - System.currentTimeMillis()) / 50.0);
+    }
+
+    public UUID getVoteId() {
+        return voteId;
+    }
+
+    public HoverableImageButton getNeedButton() {
+        return needButton;
+    }
+
+    public HoverableImageButton getGreedButton() {
+        return greedButton;
+    }
+
+    public HoverableImageButton getPassButton() {
+        return passButton;
+    }
+
+    public void initButtons(int x, int y, LootVoteScreen screen) {
+        this.x = x;
+        this.y = y;
+        needButton = new HoverableImageButton(x + 117, y + 6, 16, 16,
+                GuiTextures.NEED_BUTTON, GuiTextures.NEED_BUTTON_HOVER,
+                () -> screen.vote(voteId, VoteType.NEED), "");
+        greedButton = new HoverableImageButton(x + 116, y + 25, 17, 10,
+                GuiTextures.GREED_BUTTON, GuiTextures.GREED_BUTTON_HOVER,
+                () -> screen.vote(voteId, VoteType.GREED), "");
+        passButton = new HoverableImageButton(x + 139, y + 6, 14, 14,
+                GuiTextures.PASS_BUTTON, GuiTextures.PASS_BUTTON_HOVER,
+                () -> screen.vote(voteId, VoteType.PASS), "");
+    }
+
+    public void setPosition(int x, int y) {
+        this.x = x;
+        this.y = y;
+        if (needButton != null) {
+            needButton.setX(x + 117);
+            needButton.setY(y + 6);
+        }
+        if (greedButton != null) {
+            greedButton.setX(x + 116);
+            greedButton.setY(y + 25);
+        }
+        if (passButton != null) {
+            passButton.setX(x + 139);
+            passButton.setY(y + 6);
+        }
+    }
+
+    public boolean tick() {
+        timerTicks = (int)Math.ceil(Math.max(0, endTime - System.currentTimeMillis()) / 50.0);
+        return timerTicks <= 0;
+    }
+
+    public void render(GuiGraphics gui, int mouseX, int mouseY, Font font) {
+        ItemStack stack = items.get(0);
+
+        RenderSystem.setShaderTexture(0, GuiTextures.LOOTFRAME);
+        gui.blit(GuiTextures.LOOTFRAME, x, y, 0, 0, 160, 40, 160, 40);
+
+        int itemX = x + 8;
+        int itemY = y + 10;
+        gui.renderItem(stack, itemX, itemY);
+        if (mouseX >= itemX && mouseX <= itemX + 16 && mouseY >= itemY && mouseY <= itemY + 16) {
+            gui.renderTooltip(font, stack, mouseX, mouseY);
+        }
+        LootVoteScreen.drawScaledString(gui, font, stack.getDisplayName().getString(), x + 33, y + 9, 0.4f, 0xFFFFFF);
+        float progress = timerTicks / 600.0f;
+        drawProgressBar(gui, progress, x + 6, y + 33, 104, 5, 0xFFB2CA5D);
+    }
+
+    private void drawProgressBar(GuiGraphics graphics, float progress, int x, int y, int width, int height, int color) {
+        progress = Math.min(Math.max(progress, 0.0f), 1.0f);
+        int filledWidth = (int) (width * progress);
+        graphics.fill(x, y, x + filledWidth, y + height, color);
+    }
+}


### PR DESCRIPTION
## Summary
- add `VoteUIEntry` to represent an individual vote entry
- allow retrieving vote data from `ClientVoteCache`
- rewrite `LootVoteScreen` to display all pending votes
- open vote screen without arguments

## Testing
- `./gradlew test` *(fails: JAVA_HOME not set)*

------
https://chatgpt.com/codex/tasks/task_e_687d23f9c59c832186eada3ee43067e7