### PR TITLE
Add translation keys for vote chat

### DIFF
--- a/src/main/resources/assets/lootroll/lang/en_us.json
+++ b/src/main/resources/assets/lootroll/lang/en_us.json
@@ -1,4 +1,11 @@
 {
   "player.roll.result": "§e§l%1$s rolls %2$d (%3$d-%4$d)",
-  "key.lootroll.open_vote_menu": "Open Loot Vote Menu"
-}
+  "key.lootroll.open_vote_menu": "Open Loot Vote Menu",
+  "lootroll.vote.result": "Vote results for lot: %s",
+  "lootroll.vote.entry": " - %s %s (%s)",
+  "lootroll.vote.winner": "Winner: %s",
+  "lootroll.vote.won": "🎉 You won the lot!",
+  "lootroll.vote.pass": "%s passes on %s",
+  "lootroll.vote.roll": "%s rolls %s for %s (%s)",
+  "lootroll.vote.already_voted": "You have already voted"
+ }

--- a/src/main/resources/assets/lootroll/lang/ru_ru.json
+++ b/src/main/resources/assets/lootroll/lang/ru_ru.json
@@ -1,3 +1,10 @@
 {
-  "player.roll.result": "%1$s бросил кубик и получил %2$d (%3$d–%4$d)"
-}
+  "player.roll.result": "%1$s бросил кубик и получил %2$d (%3$d–%4$d)",
+  "lootroll.vote.result": "Результаты голосования за лот: %s",
+  "lootroll.vote.entry": " - %s %s (%s)",
+  "lootroll.vote.winner": "Победитель: %s",
+  "lootroll.vote.won": "🎉 Вы выиграли лот!",
+  "lootroll.vote.pass": "%s пасует за %s",
+  "lootroll.vote.roll": "%s бросает %s за %s (%s)",
+  "lootroll.vote.already_voted": "Вы уже проголосовали"
+ }

--- a/src/main/resources/assets/lootroll/lang/uk_ua.json
+++ b/src/main/resources/assets/lootroll/lang/uk_ua.json
@@ -1,3 +1,10 @@
 {
-  "player.roll.result": "%1$s кинув кубик і отримав %2$d (%3$d–%4$d)"
-}
+  "player.roll.result": "%1$s кинув кубик і отримав %2$d (%3$d–%4$d)",
+  "lootroll.vote.result": "Результати голосування за лот: %s",
+  "lootroll.vote.entry": " - %s %s (%s)",
+  "lootroll.vote.winner": "Переможець: %s",
+  "lootroll.vote.won": "🎉 Ви виграли лот!",
+  "lootroll.vote.pass": "%s пасує за %s",
+  "lootroll.vote.roll": "%s кидає %s за %s (%s)",
+  "lootroll.vote.already_voted": "Ви вже проголосували"
+ }


### PR DESCRIPTION
## Summary
- add interactive item components in `VoteManager`
- translate all vote messages and color them green
- provide language strings for English, Russian, and Ukrainian locales

## Testing
- `./gradlew --version` *(fails: HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687d27c10a8c8321850e1e4a3189c1af