### PR TITLE
Fix Vote screen sync

### DIFF
--- a/src/main/java/org/deymosko/lootroll/gui/LootVoteScreen.java
+++ b/src/main/java/org/deymosko/lootroll/gui/LootVoteScreen.java
@@ -80,6 +80,21 @@ public class LootVoteScreen extends Screen {
         for (VoteUIEntry e : expired) {
             vote(e.getVoteId(), VoteType.PASS);
         }
+
+        // Reload entries if client vote cache changed while the screen is open
+        boolean changed = entries.size() != ClientVoteCache.getPendingVotes().size();
+        if (!changed) {
+            for (UUID id : ClientVoteCache.getPendingVotes()) {
+                boolean present = entries.stream().anyMatch(e -> e.getVoteId().equals(id));
+                if (!present) {
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        if (changed) {
+            reloadEntries();
+        }
     }
 
     public void vote(UUID id, VoteType type) {


### PR DESCRIPTION
## Summary
- reload vote entries when the client vote cache changes

## Testing
- `./gradlew test` *(fails: Unable to download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_687d2e843db48321913e9af9c5b66a4c