### PR TITLE
Add translations for all messages

### DIFF
--- a/src/main/java/org/deymosko/lootroll/commands/LootRollCommand.java
+++ b/src/main/java/org/deymosko/lootroll/commands/LootRollCommand.java
@@ -37,13 +37,13 @@ public class LootRollCommand {
         try {
             player = source.getPlayerOrException();
         } catch (Exception e) {
-            source.sendFailure(Component.literal("Команда лише для гравців."));
+            source.sendFailure(Component.translatable("lootroll.command.players_only"));
             return 0;
         }
 
         ItemStack stack = player.getMainHandItem();
         if (stack.isEmpty()) {
-            player.sendSystemMessage(Component.literal("У вас немає предмета в руці."));
+            player.sendSystemMessage(Component.translatable("lootroll.command.no_item_in_hand"));
             return 0;
         }
 

--- a/src/main/java/org/deymosko/lootroll/commands/RollCommand.java
+++ b/src/main/java/org/deymosko/lootroll/commands/RollCommand.java
@@ -46,7 +46,7 @@ public class RollCommand {
         Random rand = new Random();
 
         if (min > max) {
-            source.sendFailure(Component.literal("Мінімум не може бути більшим за максимум."));
+            source.sendFailure(Component.translatable("lootroll.roll.invalid_range"));
             return 0;
         }
 
@@ -55,7 +55,7 @@ public class RollCommand {
         try {
             sender = source.getPlayerOrException();
         } catch (Exception e) {
-            source.sendFailure(Component.literal("Команда лише для гравців."));
+            source.sendFailure(Component.translatable("lootroll.command.players_only"));
             return 0;
         }
 

--- a/src/main/java/org/deymosko/lootroll/gui/LootVoteScreen.java
+++ b/src/main/java/org/deymosko/lootroll/gui/LootVoteScreen.java
@@ -18,7 +18,7 @@ public class LootVoteScreen extends Screen {
     private final List<VoteUIEntry> entries = new ArrayList<>();
 
     public LootVoteScreen() {
-        super(Component.literal("Loot Vote"));
+        super(Component.translatable("screen.lootroll.vote"));
     }
 
     @Override

--- a/src/main/java/org/deymosko/lootroll/gui/VoteHUDOverlay.java
+++ b/src/main/java/org/deymosko/lootroll/gui/VoteHUDOverlay.java
@@ -40,8 +40,12 @@ public class VoteHUDOverlay{
 
         guiGraphics.blit(texture, x, y, 0, 0, 96, 32, 96, 32);
 
-        drawScaledString(guiGraphics, mc.font, "📦 Active loot vote", x+15, y+6, 0.5f, 0xFFFF55);
-        drawScaledString(guiGraphics, mc.font, "Press [G] to vote", x+15, y+16, 0.5f, 0xFFFF55);
+        drawScaledString(guiGraphics, mc.font,
+                Component.translatable("lootroll.hud.active_vote").getString(),
+                x+15, y+6, 0.5f, 0xFFFF55);
+        drawScaledString(guiGraphics, mc.font,
+                Component.translatable("lootroll.hud.press_to_vote").getString(),
+                x+15, y+16, 0.5f, 0xFFFF55);
     });
 
     public static void drawScaledString(GuiGraphics guiGraphics, Font font, String text, float screenX, float screenY, float scale, int color) {

--- a/src/main/resources/assets/lootroll/lang/en_us.json
+++ b/src/main/resources/assets/lootroll/lang/en_us.json
@@ -8,4 +8,10 @@
   "lootroll.vote.pass": "%s passes on %s",
   "lootroll.vote.roll": "%s rolls %s for %s (%s)",
   "lootroll.vote.already_voted": "You have already voted"
- }
+  ,"lootroll.command.players_only": "This command is for players only."
+  ,"lootroll.command.no_item_in_hand": "You have no item in your hand."
+  ,"lootroll.roll.invalid_range": "Minimum cannot be greater than maximum."
+  ,"screen.lootroll.vote": "Loot Vote"
+  ,"lootroll.hud.active_vote": "\ud83d\udce6 Active loot vote"
+  ,"lootroll.hud.press_to_vote": "Press [G] to vote"
+}

--- a/src/main/resources/assets/lootroll/lang/ru_ru.json
+++ b/src/main/resources/assets/lootroll/lang/ru_ru.json
@@ -6,5 +6,11 @@
   "lootroll.vote.won": "🎉 Вы выиграли лот!",
   "lootroll.vote.pass": "%s пасует за %s",
   "lootroll.vote.roll": "%s бросает %s за %s (%s)",
-  "lootroll.vote.already_voted": "Вы уже проголосовали"
- }
+  "lootroll.vote.already_voted": "Вы уже проголосовали",
+  "lootroll.command.players_only": "Команда доступна только для игроков.",
+  "lootroll.command.no_item_in_hand": "У вас нет предмета в руке.",
+  "lootroll.roll.invalid_range": "Минимум не может быть больше максимума.",
+  "screen.lootroll.vote": "Голосование за добычу",
+  "lootroll.hud.active_vote": "\ud83d\udce6 \u0410\u043a\u0442\u0438\u0432\u043d\u043e\u0435 \u0433\u043e\u043b\u043e\u0441\u043e\u0432\u0430\u043d\u0438\u0435 \u0437\u0430 \u0434\u043e\u0431\u044b\u0447\u0443",
+  "lootroll.hud.press_to_vote": "\u041d\u0430\u0436\u043c\u0438\u0442\u0435 [G], \u0447\u0442\u043e\u0431\u044b \u043f\u0440\u043e\u0433\u043e\u043b\u043e\u0441\u043e\u0432\u0430\u0442\u044c"
+}

--- a/src/main/resources/assets/lootroll/lang/uk_ua.json
+++ b/src/main/resources/assets/lootroll/lang/uk_ua.json
@@ -6,5 +6,11 @@
   "lootroll.vote.won": "🎉 Ви виграли лот!",
   "lootroll.vote.pass": "%s пасує за %s",
   "lootroll.vote.roll": "%s кидає %s за %s (%s)",
-  "lootroll.vote.already_voted": "Ви вже проголосували"
+  "lootroll.vote.already_voted": "Ви вже проголосували",
+  "lootroll.command.players_only": "Команда лише для гравців.",
+  "lootroll.command.no_item_in_hand": "У вас немає предмета в руці.",
+  "lootroll.roll.invalid_range": "Мінімум не може бути більшим за максимум.",
+  "screen.lootroll.vote": "Голосування за здобич",
+  "lootroll.hud.active_vote": "\ud83d\udce6 \u0410\u043a\u0442\u0438\u0432\u043d\u0435 \u0433\u043e\u043b\u043e\u0441\u0443\u0432\u0430\u043d\u043d\u044f \u0437\u0430 \u0437\u0434\u043e\u0431\u0438\u0447",
+  "lootroll.hud.press_to_vote": "\u041d\u0430\u0442\u0438\u0441\u043d\u0456\u0442\u044c [G], \u0449\u043e\u0431 \u043f\u0440\u043e\u0433\u043e\u043b\u043e\u0441\u0443\u0432\u0430\u0442\u0438"
  }


### PR DESCRIPTION
## Summary
- make player-facing messages use `Component.translatable`
- provide English, Russian and Ukrainian translations for new keys

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687d47a2f1748321bdfe612e50853fc7